### PR TITLE
Import reduce() from functools

### DIFF
--- a/frozenordereddict/__init__.py
+++ b/frozenordereddict/__init__.py
@@ -3,6 +3,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
+from functools import reduce
 
 import operator
 


### PR DESCRIPTION
reduce() is no longer a builtin in Python 3.